### PR TITLE
PSR-12, new rules, autoloader

### DIFF
--- a/Eventjet/ruleset.xml
+++ b/Eventjet/ruleset.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0"?>
-<ruleset name="Eventjet Coding Standard">
+<ruleset name="Eventjet"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../vendor/squizlabs/php_codesniffer/phpcs.xsd"
+>
     <description>Eventjet Coding Standard</description>
 
-    <!-- include slevomat rules, relative path from PHPCS source location -->
-    <config name="installed_paths" value="../../slevomat/coding-standard"/>
-
-    <!-- base rule: PSR2 -->
-    <rule ref="PSR2"/>
+    <!-- base rule: PSR-12 -->
+    <rule ref="PSR12"/>
 
     <!-- Bans the use of the PHP long array syntax -->
     <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
@@ -140,10 +140,9 @@
     <!-- checks if Throwable is used instead of Exception -->
     <rule ref="SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly"/>
 
-    <!-- Require presence of declare(strict_types=1) -->
     <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
         <properties>
-            <property name="newlinesCountBetweenOpenTagAndDeclare" value="0"/>
+            <property name="newlinesCountBetweenOpenTagAndDeclare" value="2"/>
             <property name="spacesCountAroundEqualsSign" value="0"/>
             <property name="newlinesCountAfterDeclare" value="2"/>
         </properties>
@@ -184,23 +183,6 @@
     and semicolon and disallows use of bracketed syntax. -->
     <rule ref="SlevomatCodingStandard.Namespaces.NamespaceDeclaration"/>
 
-    <!-- Enforces configurable number of lines before and after namespace -->
-    <rule ref="SlevomatCodingStandard.Namespaces.NamespaceSpacing">
-        <properties>
-            <property name="linesCountBeforeNamespace" value="1"/>
-            <property name="linesCountAfterNamespace" value="1"/>
-        </properties>
-    </rule>
-
-    <!-- Configurable number of lines before first use, after last use and between two different types of use -->
-    <rule ref="SlevomatCodingStandard.Namespaces.UseSpacing">
-        <properties>
-            <property name="linesCountBeforeFirstUse" value="1"/>
-            <property name="linesCountBetweenUseTypes" value="0"/>
-            <property name="linesCountAfterLastUse" value="1"/>
-        </properties>
-    </rule>
-
     <!-- Enforces using shorthand scalar typehint variants in phpDocs -->
     <rule ref="SlevomatCodingStandard.TypeHints.LongTypeHints"/>
 
@@ -216,7 +198,9 @@
 
     <!-- Enforces consistent formatting of return typehints -->
     <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing">
-        <property name="spacesCountBeforeColon" value="0"/>
+        <properties>
+            <property name="spacesCountBeforeColon" value="0"/>
+        </properties>
     </rule>
 
     <!-- Checks that there's a single space between a typehint and a parameter name
@@ -234,4 +218,48 @@
 
     <!-- Require ? when default value is null -->
     <rule ref="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue"/>
+
+    <!-- Forbid PHP 4 constructors -->
+    <rule ref="Generic.NamingConventions.ConstructorName"/>
+
+    <!-- Force PHP 7 param and return types to be lowercased -->
+    <rule ref="Generic.PHP.LowerCaseType"/>
+
+    <!-- Forbid useless comments -->
+    <rule ref="SlevomatCodingStandard.Commenting.ForbiddenComments">
+        <properties>
+            <property name="forbiddenCommentPatterns" type="array">
+                <element value="~^(?:(?!private|protected|static)\S+ )?(?:con|de)structor\.\z~i"/>
+                <element value="~^Created by .+\.\z~i"/>
+                <element value="~^(User|Date|Time): \S+\z~i"/>
+                <element value="~^\S+ [gs]etter\.\z~i"/>
+                <element value="~^Class \S+\z~i"/>
+            </property>
+        </properties>
+    </rule>
+
+    <!-- Require new instances with parentheses -->
+    <rule ref="SlevomatCodingStandard.ControlStructures.NewWithParentheses"/>
+
+    <!-- Forbid usage of conditions when a simple return can be used -->
+    <rule ref="SlevomatCodingStandard.ControlStructures.UselessIfConditionWithReturn"/>
+
+    <!-- Forbid unused variables passed to closures via `use` -->
+    <rule ref="SlevomatCodingStandard.Functions.UnusedInheritedVariablePassedToClosure"/>
+
+    <!-- Forbid useless parentheses -->
+    <rule ref="SlevomatCodingStandard.PHP.UselessParentheses"/>
+
+    <!-- Forbid class being in a file with different name -->
+    <rule ref="Squiz.Classes.ClassFileName"/>
+    <!-- Force `self::` for self-reference, force lower-case self, forbid spaces around `::` -->
+    <rule ref="Squiz.Classes.SelfMemberReference"/>
+
+    <rule ref="Squiz.NamingConventions.ValidVariableName">
+        <exclude name="Squiz.NamingConventions.ValidVariableName.PrivateNoUnderscore"/>
+    </rule>
+
+    <!-- Require PHP function calls in lowercase -->
+    <rule ref="Squiz.PHP.LowercasePHPFunctions"/>
+
 </ruleset>

--- a/Eventjet/ruleset.xml
+++ b/Eventjet/ruleset.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0"?>
-<ruleset name="Eventjet"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="../vendor/squizlabs/php_codesniffer/phpcs.xsd"
+<ruleset
+        name="Eventjet"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="../vendor/squizlabs/php_codesniffer/phpcs.xsd"
 >
     <description>Eventjet Coding Standard</description>
 

--- a/EventjetStrict/ruleset.xml
+++ b/EventjetStrict/ruleset.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0"?>
-<ruleset name="EventjetStrict">
+<ruleset
+        name="EventjetStrict"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="../vendor/squizlabs/php_codesniffer/phpcs.xsd"
+>
     <description>Eventjet Strict Coding Standard</description>
 
     <!-- include all regular rules -->

--- a/EventjetStrict/ruleset.xml
+++ b/EventjetStrict/ruleset.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
-<ruleset name="Eventjet Strict Coding Standard">
+<ruleset name="EventjetStrict">
     <description>Eventjet Strict Coding Standard</description>
 
     <!-- include all regular rules -->
-    <rule ref="./ruleset.xml"/>
+    <rule ref="Eventjet"/>
 
     <!-- Require types to be written as natively if possible;
             require iterable types to specify phpDoc with their content;

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 Add the following `phpcs.xml` file to your project's root:
 ```xml
 <?xml version="1.0"?>
-<ruleset name="Eventjet Coding Standard">
-    <rule ref="./vendor/eventjet/coding-standard/ruleset.xml"/>
+<ruleset>
+    <rule ref="Eventjet"/>
 
     <file>src</file>
     <file>tests</file>
@@ -13,19 +13,19 @@ Add the following `phpcs.xml` file to your project's root:
 ```
 
 ## More strict rules:
-There is also a `ruleset_strict.xml` which adds the
+There is also a more strict ruleset which adds the
 [SlevomatCodingStandard.TypeHints.TypeHintDeclaration](https://github.com/slevomat/coding-standard#slevomatcodingstandardtypehintstypehintdeclaration-) sniff.
 
 This sniff can be problematic: If you implement interfaces or have your own interfaces which don't have
 parameter type hints and return types set, enforcing this sniff would lead to a BC break.
 This sniff is also set to `phpcs-only`, so `phpcbf` _won't_ fix errors automatically. 
 
-To use this ruleset, just use the use the corresponding file in your phpcs rule ref instead of the default one:
+To use this ruleset, just use the use the corresponding rule name in your phpcs rule ref instead of the default one:
 
 ```xml
 <?xml version="1.0"?>
-<ruleset name="Eventjet Coding Standard">
-    <rule ref="./vendor/eventjet/coding-standard/ruleset_strict.xml"/>
+<ruleset>
+    <rule ref="EventjetStrict"/>
 
     <file>src</file>
     <file>tests</file>
@@ -45,8 +45,8 @@ To exclude a sniff for a certain set of files, reference  the rule explicitly an
 It is also possible to exclude a sniff completely:
 ```xml
 <?xml version="1.0"?>
-<ruleset name="Eventjet Coding Standard">
-    <rule ref="./vendor/eventjet/coding-standard/ruleset.xml">
+<ruleset>
+    <rule ref="Eventjet">
         <exclude name="SlevomatCodingStandard.Classes.ClassConstantVisibility"/>
     </rule>
 

--- a/composer.json
+++ b/composer.json
@@ -14,18 +14,25 @@
         }
     ],
     "require": {
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
         "slevomat/coding-standard": "^5.0",
         "squizlabs/php_codesniffer": "^3.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0"
     },
+    "config": {
+        "sort-packages": true
+    },
+    "autoload": {
+        "psr-4": {
+            "Eventjet\\CodingStandard\\": "Eventjet",
+            "Eventjet\\CodingStandard\\Strict\\": "EventjetStrict"
+        }
+    },
     "autoload-dev": {
         "psr-4": {
             "Eventjet\\CodingStandard\\Test\\": "tests"
         }
-    },
-    "config": {
-        "sort-packages": true
     }
 }

--- a/tests/fixtures/invalid/cast-space.php
+++ b/tests/fixtures/invalid/cast-space.php
@@ -1,3 +1,5 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 $x = (bool) 23;

--- a/tests/fixtures/invalid/import-constant-before-function.php
+++ b/tests/fixtures/invalid/import-constant-before-function.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Eventjet;
 
 use const E_USER_DEPRECATED;
+
 use function trigger_error;
 
 trigger_error('Test', E_USER_DEPRECATED);

--- a/tests/fixtures/invalid/multiline-array-no-trailing-comma.php
+++ b/tests/fixtures/invalid/multiline-array-no-trailing-comma.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 $x = [
     'foo'

--- a/tests/fixtures/valid/cast-no-space.php
+++ b/tests/fixtures/valid/cast-no-space.php
@@ -1,3 +1,5 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 $x = (bool)23;

--- a/tests/fixtures/valid/multiline-array-trailing-comma.php
+++ b/tests/fixtures/valid/multiline-array-trailing-comma.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 $x = [
     'foo',

--- a/tests/fixtures/valid/psr-12-import-order.php
+++ b/tests/fixtures/valid/psr-12-import-order.php
@@ -1,9 +1,17 @@
-<?php declare(strict_types=1);
+<?php
+
+/**
+ * File Level Docblock
+ */
+
+declare(strict_types=1);
 
 namespace Eventjet;
 
 use stdClass;
+
 use function trigger_error;
+
 use const E_USER_DEPRECATED;
 
 new stdClass();


### PR DESCRIPTION
* switch over to psr-12
* add some new sniffs (mostly borrowed from Doctrine coding standard)
* use phpcodesniffer-composer-installer to automatically register rulesets

Target version: `3.0`