### PR TITLE
add new rules for global functions and constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
-## 3.2.0 - TBD
+## 3.2.0 - 2020-10-13
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 3.2.0 - TBD
+
+### Added
+
+- [#10](https://github.com/eventjet/coding-standard/pull/10) adds two new rules: enforce importing of global constants and functions
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
 ## 3.1.1 - 2020-09-07
 
 ### Added

--- a/Eventjet/ruleset.xml
+++ b/Eventjet/ruleset.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <ruleset
-        name="Eventjet"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="../vendor/squizlabs/php_codesniffer/phpcs.xsd"
+    name="Eventjet"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="../vendor/squizlabs/php_codesniffer/phpcs.xsd"
 >
     <description>Eventjet Coding Standard</description>
 
@@ -41,9 +41,9 @@
     <rule ref="Generic.PHP.ForbiddenFunctions">
         <properties>
             <property
-                    name="forbiddenFunctions"
-                    type="array"
-                    value="
+                name="forbiddenFunctions"
+                type="array"
+                value="
                     chop => rtrim,
                     close => closedir,
                     compact => null,
@@ -117,9 +117,9 @@
     <rule ref="SlevomatCodingStandard.Commenting.ForbiddenAnnotations">
         <properties>
             <property
-                    name="forbiddenAnnotations"
-                    type="array"
-                    value="
+                name="forbiddenAnnotations"
+                type="array"
+                value="
                     @api,
                     @author,
                     @category,
@@ -268,11 +268,16 @@
     <!-- no space after closing parenthesis and colon in alternate control structures -->
     <rule ref="Squiz.ControlStructures.ControlSignature">
         <properties>
-            <property name="requiredSpacesBeforeColon" value="0" />
+            <property name="requiredSpacesBeforeColon" value="0"/>
         </properties>
     </rule>
 
     <!-- Checks that there's a single space between a typehint and a parameter name
      and that there's no whitespace between a nullability symbol and a typehint -->
     <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHintSpacing"/>
+
+    <!-- Internal functions MUST be imported. -->
+    <rule ref="WebimpressCodingStandard.PHP.ImportInternalFunction"/>
+    <!-- Internal constants MUST be imported. -->
+    <rule ref="WebimpressCodingStandard.PHP.ImportInternalConstant"/>
 </ruleset>

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Eventjet
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         "php": "^7.1",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6 || ^0.7",
         "slevomat/coding-standard": "^6.0",
-        "squizlabs/php_codesniffer": "^3.5"
+        "squizlabs/php_codesniffer": "^3.5",
+        "webimpress/coding-standard": "^1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.3"

--- a/tests/RulesTest.php
+++ b/tests/RulesTest.php
@@ -49,14 +49,14 @@ final class RulesTest extends TestCase
             $output
         );
         $message = implode("\n", $lines);
-        $this->assertSame(0, $return, $message);
+        self::assertSame(0, $return, $message);
     }
 
     private function assertIsInvalid(string $file): void
     {
         $command = sprintf('%s/../vendor/bin/phpcs --standard=Eventjet %s', __DIR__, $file);
         exec($command, $output, $return);
-        $this->assertNotSame(0, $return, sprintf('Failed asserting that %s is invalid.', $file));
+        self::assertNotSame(0, $return, sprintf('Failed asserting that %s is invalid.', $file));
     }
 
     private function gatherFiles(string $directory): array

--- a/tests/fixtures/invalid/global-constant-fully-qualified.php
+++ b/tests/fixtures/invalid/global-constant-fully-qualified.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Invalid;
+
+$foo = \PHP_VERSION;

--- a/tests/fixtures/invalid/global-constant-not-imported.php
+++ b/tests/fixtures/invalid/global-constant-not-imported.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Invalid;
+
+$foo = PHP_VERSION;

--- a/tests/fixtures/invalid/global-function-fully-qualified.php
+++ b/tests/fixtures/invalid/global-function-fully-qualified.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Invalid;
+
+$foo = \strlen('bar');

--- a/tests/fixtures/invalid/global-function-not-imported.php
+++ b/tests/fixtures/invalid/global-function-not-imported.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Invalid;
+
+$foo = strlen('bar');

--- a/tests/fixtures/valid/import-global-constant.php
+++ b/tests/fixtures/valid/import-global-constant.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Valid;
+
+use const PHP_VERSION;
+
+$foo = PHP_VERSION;

--- a/tests/fixtures/valid/import-global-function.php
+++ b/tests/fixtures/valid/import-global-function.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Valid;
+
+use function strlen;
+
+$foo = strlen('bar');


### PR DESCRIPTION
I'd like to introduce two new rules:

* all global constants must be imported (fully qualified notation is not allowed)
* all global functions must be imported (fully qualified notation is not allowed)

That means that all global functions and constants have to be imported. Using the fully qualified name (i.e. `\strlen`) is **not** allowed.
That also means requiring a new dependency (`webimpress/coding-standard`).
