### PR TITLE
Require blank lines between methods

### DIFF
--- a/Eventjet/ruleset.xml
+++ b/Eventjet/ruleset.xml
@@ -101,6 +101,15 @@
         </properties>
     </rule>
 
+    <!-- Require blank lines between methods -->
+    <rule ref="Squiz.WhiteSpace.FunctionSpacing">
+        <properties>
+            <property name="spacing" value="1"/>
+            <property name="spacingBeforeFirst" value="0"/>
+            <property name="spacingAfterLast" value="0"/>
+        </properties>
+    </rule>
+
     <!-- Require space around logical operators -->
     <rule ref="Squiz.WhiteSpace.LogicalOperatorSpacing"/>
     <!-- Forbid spaces around `->` operator -->

--- a/tests/fixtures/invalid/BlankLineAfterLastInterfaceMethod.php
+++ b/tests/fixtures/invalid/BlankLineAfterLastInterfaceMethod.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Invalid;
+
+interface BlankLineAfterLastInterfaceMethod
+{
+    public function methodA(): void;
+
+    public function methodB(): void;
+
+}

--- a/tests/fixtures/invalid/BlankLineBeforeFirstInterfaceMethod.php
+++ b/tests/fixtures/invalid/BlankLineBeforeFirstInterfaceMethod.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Invalid;
+
+interface BlankLineBeforeFirstInterfaceMethod
+{
+
+    public function methodA(): void;
+
+    public function methodB(): void;
+}

--- a/tests/fixtures/invalid/NoEmptyLineBetweenInterfaceMethods.php
+++ b/tests/fixtures/invalid/NoEmptyLineBetweenInterfaceMethods.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Invalid;
+
+interface NoEmptyLineBetweenInterfaceMethods
+{
+    public function methodA(): void;
+    public function methodB(): void;
+}

--- a/tests/fixtures/invalid/TooManyBlankLinesBetweenInterfaceMethods.php
+++ b/tests/fixtures/invalid/TooManyBlankLinesBetweenInterfaceMethods.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Invalid;
+
+interface TooManyBlankLinesBetweenInterfaceMethods
+{
+    public function methodA(): void;
+
+
+    public function methodB(): void;
+}

--- a/tests/fixtures/valid/NoSpaceBetweenDocblockAndMethod.php
+++ b/tests/fixtures/valid/NoSpaceBetweenDocblockAndMethod.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Valid;
+
+interface NoSpaceBetweenDocblockAndMethod
+{
+    public function methodA(): void;
+
+    /**
+     * This does something
+     */
+    public function methodB(): void;
+}

--- a/tests/fixtures/valid/SingleBlankLineBetweenInterfaceMethods.php
+++ b/tests/fixtures/valid/SingleBlankLineBetweenInterfaceMethods.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Valid;
+
+interface SingleBlankLineBetweenInterfaceMethods
+{
+    public function methodA(): void;
+
+    public function methodB(): void;
+}


### PR DESCRIPTION
This makes the following code invalid:
```php
interface NoEmptyLineBetweenInterfaceMethods
{
    public function methodA(): void;
    public function methodB(): void;
}
```
This is valid:
```php
interface SingleBlankLineBetweenInterfaceMethods
{
    public function methodA(): void;

    public function methodB(): void;
}
```