### PR TITLE
Simplify bootstrapping PHP-CS-Fixer config

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -7,7 +7,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ["7.4", "8.0", "8.1"]
+        php: ["8.1", "8.2"]
         composer_flags:
           - '--prefer-lowest'
           - ''
@@ -18,14 +18,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Prepare environment
         run: |
           echo "COMPOSER_CACHE=$(composer config cache-dir)" >> $GITHUB_ENV
 
       - name: Composer Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ${{ env.COMPOSER_CACHE }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.phpunit.result.cache
 /vendor/
 /composer.lock
+/.php-cs-fixer.cache

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Eventjet\CodingStandard\PhpCsFixer\Config;
+use PhpCsFixer\Finder;
+
+$finder = Finder::create()->in(__DIR__)->exclude('tests/fixtures');
+return Config::strict($finder);

--- a/Eventjet/PhpCsFixer/Config.php
+++ b/Eventjet/PhpCsFixer/Config.php
@@ -6,13 +6,13 @@ namespace Eventjet\CodingStandard\PhpCsFixer;
 
 use PhpCsFixer\ConfigInterface;
 use PhpCsFixer\Finder;
+use RuntimeException;
 
-use function debug_backtrace;
-use function dirname;
+use function getcwd;
 
 final class Config
 {
-    public static function basic(Finder | null $finder = null): ConfigInterface
+    public static function basic(Finder|null $finder = null): ConfigInterface
     {
         $finder ??= self::createFinder();
         return (new \PhpCsFixer\Config())
@@ -21,7 +21,7 @@ final class Config
             ->setRiskyAllowed(true);
     }
 
-    public static function strict(Finder | null $finder = null): ConfigInterface
+    public static function strict(Finder|null $finder = null): ConfigInterface
     {
         $finder ??= self::createFinder();
         return (new \PhpCsFixer\Config())
@@ -53,7 +53,10 @@ final class Config
 
     private static function callingDir(): string
     {
-        $backtrace = debug_backtrace();
-        return dirname($backtrace[2]['file']);
+        $cwd = getcwd();
+        if ($cwd === false || $cwd === '') {
+            throw new RuntimeException('Could not determine the current base directory');
+        }
+        return $cwd;
     }
 }

--- a/Eventjet/PhpCsFixer/Config.php
+++ b/Eventjet/PhpCsFixer/Config.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Eventjet\CodingStandard\PhpCsFixer;
+
+use PhpCsFixer\ConfigInterface;
+use PhpCsFixer\Finder;
+
+use function debug_backtrace;
+use function dirname;
+
+final class Config
+{
+    public static function basic(Finder | null $finder = null): ConfigInterface
+    {
+        $finder ??= self::createFinder();
+        return (new \PhpCsFixer\Config())
+            ->setRules(self::basicRules())
+            ->setFinder($finder)
+            ->setRiskyAllowed(true);
+    }
+
+    public static function strict(Finder | null $finder = null): ConfigInterface
+    {
+        $finder ??= self::createFinder();
+        return (new \PhpCsFixer\Config())
+            ->setRules(self::strictRules())
+            ->setFinder($finder)
+            ->setRiskyAllowed(true);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function basicRules(): array
+    {
+        return require(__DIR__ . '/../../php-cs-fixer-rules.php');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function strictRules(): array
+    {
+        return require(__DIR__ . '/../../php-cs-fixer-rules.php');
+    }
+
+    private static function createFinder(): Finder
+    {
+        return Finder::create()->in(self::callingDir());
+    }
+
+    private static function callingDir(): string
+    {
+        $backtrace = debug_backtrace();
+        return dirname($backtrace[2]['file']);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -8,41 +8,36 @@ Add the following `.php-cs-fixer.dist.php` file to your project's root:
 
 declare(strict_types=1);
 
-$rules = include __DIR__ . '/vendor/eventjet/coding-standard/php-cs-fixer-rules.php';
-assert(is_array($rules));
+use Eventjet\CodingStandard\PhpCsFixer\Config;
 
-return (new PhpCsFixer\Config())
-    ->setRules($rules)
-    ->setFinder(PhpCsFixer\Finder::create()->in(__DIR__))
-    ->setRiskyAllowed(true);
+return Config::basic();
 ```
 
-The finder will include everything in `.` and excludes `vendor` automatically.
-If you need a more granular directory specification, an array of directories can be passed:
+This will create a basic configuration with a `Finder` that includes everything in `.` and excludes `vendor`.
+If you need a more granular directory specification, you can pass a custom `Finder`:
+
 ```php
 <?php
 
 declare(strict_types=1);
 
-$rules = include __DIR__ . '/vendor/eventjet/coding-standard/php-cs-fixer-rules.php';
-assert(is_array($rules));
-$dirs = [
-    'config',
-    'features',
-    'migrations',
-    'module',
-];
+use Eventjet\CodingStandard\PhpCsFixer\Config;
+use PhpCsFixer\Finder;
 
-return (new PhpCsFixer\Config())
-    ->setRules($rules)
-    ->setFinder(PhpCsFixer\Finder::create()->in($dirs))
-    ->setRiskyAllowed(true);
+$finder = Finder::create()->in(['features', 'module', 'tests'])->exclude('tests/fixtures');
+return Config::basic($finder);
 ```
 
 ### More strict rules:
-To use the strict rules, use the corresponding file instead of `php-cs-fixer-rules.php`:
+To use the strict rules, use the `strict` method::
 ```php
-$rules = include __DIR__ . '/vendor/eventjet/coding-standard/php-cs-fixer-strict-rules.php';
+<?php
+
+declare(strict_types=1);
+
+use Eventjet\CodingStandard\PhpCsFixer\Config;
+
+return Config::strict();
 ```
 The strict rules enforce a union syntax for nullable types, a certain method order and trailing commas everywhere.
 See [the file](https://github.com/eventjet/coding-standard/blob/master/php-cs-fixer-strict-rules.php) for details.

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1 || ^8.0",
+        "php": "^8.1",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6 || ^0.7",
         "friendsofphp/php-cs-fixer": "^3.22",
         "slevomat/coding-standard": "^8.4",
@@ -22,7 +22,7 @@
         "webimpress/coding-standard": "^1.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5.5"
+        "phpunit/phpunit": "^10.2"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -4,8 +4,6 @@
     bootstrap="vendor/autoload.php"
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
-    verbose="true"
-    convertDeprecationsToExceptions="true"
 >
     <testsuites>
         <testsuite name="Eventjet\CodingStandard">

--- a/tests/RulesTest.php
+++ b/tests/RulesTest.php
@@ -6,6 +6,7 @@ namespace Eventjet\CodingStandard\Test;
 
 use DirectoryIterator;
 use PHPUnit\Framework\TestCase;
+
 use function array_merge;
 use function basename;
 use function exec;
@@ -50,10 +51,10 @@ final class RulesTest extends TestCase
     /**
      * @return iterable<string, array{string, Tool}>
      */
-    public function valid(): iterable
+    public static function valid(): iterable
     {
         foreach (['phpcs', 'php-cs-fixer'] as $tool) {
-            foreach ($this->gatherFiles(__DIR__ . '/fixtures/valid') as $filename => $path) {
+            foreach (self::gatherFiles(__DIR__ . '/fixtures/valid') as $filename => $path) {
                 yield $tool . ': ' . $filename => [$path[0], $tool];
             }
         }
@@ -75,10 +76,10 @@ final class RulesTest extends TestCase
     /**
      * @return iterable<string, array{string, Tool}>
      */
-    public function invalid(): iterable
+    public static function invalid(): iterable
     {
         foreach (['phpcs', 'php-cs-fixer'] as $tool) {
-            foreach ($this->gatherFiles(__DIR__ . '/fixtures/invalid') as $filename => $path) {
+            foreach (self::gatherFiles(__DIR__ . '/fixtures/invalid') as $filename => $path) {
                 yield $tool . ': ' . $filename => [$path[0], $tool];
             }
         }
@@ -116,7 +117,7 @@ final class RulesTest extends TestCase
     /**
      * @return array<string, array{string}>
      */
-    private function gatherFiles(string $directory): array
+    private static function gatherFiles(string $directory): array
     {
         $files = [];
         foreach (new DirectoryIterator($directory) as $file) {


### PR DESCRIPTION
* add a method to create a PhpCsFixer config with defaults
* bump minimum php version to 8.1
* upgrade phpunit