### PR TITLE
Replace deprecated PHP-CS-Fixer rule

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^8.1",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6 || ^0.7 || ^1.0",
-        "friendsofphp/php-cs-fixer": "^3.22",
+        "friendsofphp/php-cs-fixer": "^3.32",
         "slevomat/coding-standard": "^8.4",
         "squizlabs/php_codesniffer": "^3.6.1",
         "webimpress/coding-standard": "^1.1"

--- a/php-cs-fixer-rules.php
+++ b/php-cs-fixer-rules.php
@@ -34,7 +34,7 @@ return [
         'scope' => 'namespaced',
         'strict' => true,
     ],
-    'new_with_braces' => [
+    'new_with_parentheses' => [
         'named_class' => true,
         'anonymous_class' => false,
     ],


### PR DESCRIPTION
`new_with_braces` is deprecated in favor of `new_with_parentheses`