### PR TITLE
Disallow multiple classes per file

### DIFF
--- a/tests/RulesTest.php
+++ b/tests/RulesTest.php
@@ -30,6 +30,8 @@ final class RulesTest extends TestCase
         // PHPCS doesn't seem to have a rule for heredoc/nowdoc indentation
         ['NowdocNotIndented.php', 'phpcs'],
         ['HeredocNotIndented.php', 'phpcs'],
+        // PHP CS Fixer has no rule for multiple classes per file
+        ['multiple-classes-per-file.php', 'php-cs-fixer'],
     ];
 
     private static function phpCsFixerCommand(string $file): string

--- a/tests/fixtures/invalid/multiple-classes-per-file.php
+++ b/tests/fixtures/invalid/multiple-classes-per-file.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Invalid;
+
+class Foo
+{
+}
+
+class Bar
+{
+}


### PR DESCRIPTION
## Summary

- Adds an invalid fixture for multiple classes in a single file
- Enforced by PHPCS via `PSR1.Classes.ClassDeclaration`
- PHP CS Fixer has no equivalent rule (it's a transformer, not a linter — report-only rules aren't possible), so the fixture is skipped for that tool

## Test plan

- [ ] `./vendor/bin/phpunit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)