### PR TITLE
Allow @api annotation

### DIFF
--- a/Eventjet/ruleset.xml
+++ b/Eventjet/ruleset.xml
@@ -137,7 +137,6 @@
                 name="forbiddenAnnotations"
                 type="array"
                 value="
-                    @api,
                     @author,
                     @category,
                     @copyright,

--- a/php-cs-fixer-rules.php
+++ b/php-cs-fixer-rules.php
@@ -25,7 +25,6 @@ return [
     ],
     'general_phpdoc_annotation_remove' => [
         'annotations' => [
-            'api',
             'author',
             'category',
             'copyright',

--- a/tests/fixtures/valid/api-annotation.php
+++ b/tests/fixtures/valid/api-annotation.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @api
+ */
+function foo(): void
+{
+}


### PR DESCRIPTION
## Summary
- `@api` is meaningful (used by PHPStan, Psalm, IDEs to mark public API surface), unlike the other forbidden tags (`@author`, `@version`, etc.) which Git/LICENSE already cover.
- Removed `@api` from `SlevomatCodingStandard.Commenting.ForbiddenAnnotations` in `Eventjet/ruleset.xml`.
- Removed `'api'` from `general_phpdoc_annotation_remove` in `php-cs-fixer-rules.php`.
- Added `tests/fixtures/valid/api-annotation.php` so a future re-add fails the test suite.

## Test plan
- [x] `vendor/bin/phpunit` — 208 tests pass (phpcs + php-cs-fixer both accept the new fixture)

🤖 Generated with [Claude Code](https://claude.com/claude-code)